### PR TITLE
fix ValueError: Cannot serialize: <cred.storage.CredAttachmentStorage…

### DIFF
--- a/cred/storage.py
+++ b/cred/storage.py
@@ -1,6 +1,8 @@
 from database_files.storage import DatabaseStorage
+from django.utils.deconstruct import deconstructible
 
 
+@deconstructible
 class CredAttachmentStorage(DatabaseStorage):
     def url(self, name):
         return 'Not used in RatticDB. If you see this please raise a bug.'


### PR DESCRIPTION
fix `ValueError: Cannot serialize: <cred.storage.CredAttachmentStorage object at 0x3a02d90>`

see also: https://docs.djangoproject.com/en/1.8/topics/migrations/#adding-a-deconstruct-method